### PR TITLE
Fix the bug when processing CIDR prefix

### DIFF
--- a/src/Utils/IPRange.swift
+++ b/src/Utils/IPRange.swift
@@ -31,7 +31,7 @@ public class IPRange {
             throw IPRangeError.InvalidCIDRFormat
         }
 
-        try self.init(baseIP: ip, range: UInt32.max >> mask)
+        try self.init(baseIP: ip, range: (1 << (32 - mask)) - 1 )
     }
 
     public convenience init(withRangeString rep: String) throws {


### PR DESCRIPTION
When CIDR Prefix equals 32 in IP range list, SpechtLite, and maybe other apps using NEKit, will crash without any info.

Tested with Xcode and it throws an error "shift amount is greater than or equal to type size in bits" when running `UInt32.max >> mask` in src/Utils/IPRange.swift.

This pull request fixes that bug by changing the way transforming the CIDR prefix to the IP range.