### PR TITLE
use non-optional value to comparison

### DIFF
--- a/src/Utils/Checksum.swift
+++ b/src/Utils/Checksum.swift
@@ -1,28 +1,4 @@
 import Foundation
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l < r
-  case (nil, _?):
-    return true
-  default:
-    return false
-  }
-}
-
-// FIXME: comparison operators with optionals were removed from the Swift Standard Libary.
-// Consider refactoring the code to use the non-optional operators.
-fileprivate func <= <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
-  switch (lhs, rhs) {
-  case let (l?, r?):
-    return l <= r
-  default:
-    return !(rhs < lhs)
-  }
-}
-
 
 open class Checksum {
 
@@ -43,7 +19,7 @@ open class Checksum {
         if end == nil {
             end = data.count
         }
-        while scanner.position + 2 <= end {
+        while scanner.position + 2 <= end! {
             let value = scanner.read16()!
             result += UInt32(value)
         }


### PR DESCRIPTION
As comparison operators with optionals were removed from the Swift Stand Library and the "end" variable would never be nil.