### PR TITLE
To temporarily solve a bug in firefox for mac

### DIFF
--- a/src/Utils/HTTPStreamScanner.swift
+++ b/src/Utils/HTTPStreamScanner.swift
@@ -27,6 +27,10 @@ class HTTPStreamScanner {
             let header: HTTPHeader
             do {
                 header = try HTTPHeader(headerData: data)
+                // To temporarily solve a bug in firefox for mac
+                if currentHeader != nil && header.host != currentHeader.host {
+                    throw HTTPStreamScannerError.scannerIsStopped
+                }
             } catch let error {
                 nextAction = .stop
                 throw error

--- a/src/Utils/HTTPStreamScanner.swift
+++ b/src/Utils/HTTPStreamScanner.swift
@@ -10,7 +10,7 @@ class HTTPStreamScanner {
     }
     
     enum HTTPStreamScannerError: Error {
-        case contentIsTooLong, scannerIsStopped
+        case contentIsTooLong, scannerIsStopped, unsupportedStreamType
     }
     
     var nextAction: ReadAction = .readHeader
@@ -29,7 +29,7 @@ class HTTPStreamScanner {
                 header = try HTTPHeader(headerData: data)
                 // To temporarily solve a bug in firefox for mac
                 if currentHeader != nil && header.host != currentHeader.host {
-                    throw HTTPStreamScannerError.scannerIsStopped
+                    throw HTTPStreamScannerError.unsupportedStreamType
                 }
             } catch let error {
                 nextAction = .stop


### PR DESCRIPTION
There is a bug in firefox for mac. Sometimes firefox just open a socket
to process multiple domains(This case is common in weibo.com if you click a short link to jump to another site). That cause the NEKit will send HTTP
content to wrong host. To completely solve this case, we need to find
out a method to handle one socket multiple domains.