### PR TITLE
Mark `getAdapterFor` method of `AdapterFactory` public.

### DIFF
--- a/src/Socket/AdapterSocket/AdapterSocket.swift
+++ b/src/Socket/AdapterSocket/AdapterSocket.swift
@@ -19,7 +19,7 @@ open class AdapterSocket: NSObject, SocketProtocol, RawTCPSocketDelegate {
 
      - parameter session: The connect session.
      */
-    func openSocketWith(session: ConnectSession) {
+    open func openSocketWith(session: ConnectSession) {
         guard !isCancelled else {
             return
         }

--- a/src/Socket/AdapterSocket/AdapterSocket.swift
+++ b/src/Socket/AdapterSocket/AdapterSocket.swift
@@ -10,7 +10,7 @@ open class AdapterSocket: NSObject, SocketProtocol, RawTCPSocketDelegate {
     }
 
     internal var _cancelled = false
-    var isCancelled: Bool {
+    public var isCancelled: Bool {
         return _cancelled
     }
 

--- a/src/Socket/AdapterSocket/Factory/AdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/AdapterFactory.swift
@@ -11,7 +11,7 @@ open class AdapterFactory {
 
      - returns: The built adapter.
      */
-    public func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         return getDirectAdapter()
     }
 
@@ -20,7 +20,7 @@ open class AdapterFactory {
 
      - returns: A direct adapter.
      */
-    func getDirectAdapter() -> AdapterSocket {
+    public func getDirectAdapter() -> AdapterSocket {
         let adapter = DirectAdapter()
         adapter.socket = RawSocketFactory.getRawSocket()
         return adapter

--- a/src/Socket/AdapterSocket/Factory/AdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/AdapterFactory.swift
@@ -11,7 +11,7 @@ open class AdapterFactory {
 
      - returns: The built adapter.
      */
-    func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    public func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         return getDirectAdapter()
     }
 

--- a/src/Socket/AdapterSocket/Factory/HTTPAdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/HTTPAdapterFactory.swift
@@ -13,7 +13,7 @@ open class HTTPAdapterFactory: HTTPAuthenticationAdapterFactory {
 
      - returns: The built adapter.
      */
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         let adapter = HTTPAdapter(serverHost: serverHost, serverPort: serverPort, auth: auth)
         adapter.socket = RawSocketFactory.getRawSocket()
         return adapter

--- a/src/Socket/AdapterSocket/Factory/RejectAdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/RejectAdapterFactory.swift
@@ -7,7 +7,7 @@ open class RejectAdapterFactory: AdapterFactory {
         self.delay = delay
     }
 
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         return RejectAdapter(delay: delay)
     }
 }

--- a/src/Socket/AdapterSocket/Factory/SOCKS5AdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/SOCKS5AdapterFactory.swift
@@ -13,7 +13,7 @@ open class SOCKS5AdapterFactory: ServerAdapterFactory {
 
      - returns: The built adapter.
      */
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         let adapter = SOCKS5Adapter(serverHost: serverHost, serverPort: serverPort)
         adapter.socket = RawSocketFactory.getRawSocket()
         return adapter

--- a/src/Socket/AdapterSocket/Factory/SecureHTTPAdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/SecureHTTPAdapterFactory.swift
@@ -13,7 +13,7 @@ open class SecureHTTPAdapterFactory: HTTPAdapterFactory {
 
      - returns: The built adapter.
      */
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         let adapter = SecureHTTPAdapter(serverHost: serverHost, serverPort: serverPort, auth: auth)
         adapter.socket = RawSocketFactory.getRawSocket()
         return adapter

--- a/src/Socket/AdapterSocket/Factory/ShadowsocksAdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/ShadowsocksAdapterFactory.swift
@@ -20,7 +20,7 @@ open class ShadowsocksAdapterFactory: ServerAdapterFactory {
 
      - returns: The built adapter.
      */
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         let adapter = ShadowsocksAdapter(host: serverHost, port: serverPort, protocolObfuscater: protocolObfuscaterFactory.build(), cryptor: cryptorFactory.build(), streamObfuscator: streamObfuscaterFactory.build(for: session))
         adapter.socket = RawSocketFactory.getRawSocket()
         return adapter

--- a/src/Socket/AdapterSocket/Factory/SpeedAdapterFactory.swift
+++ b/src/Socket/AdapterSocket/Factory/SpeedAdapterFactory.swift
@@ -13,7 +13,7 @@ open class SpeedAdapterFactory: AdapterFactory {
 
      - returns: The built adapter.
      */
-    override func getAdapterFor(session: ConnectSession) -> AdapterSocket {
+    override open func getAdapterFor(session: ConnectSession) -> AdapterSocket {
         let adapters = adapterFactories.map { adapterFactory, delay -> (AdapterSocket, Int) in
             let adapter = adapterFactory.getAdapterFor(session: session)
             adapter.socket = RawSocketFactory.getRawSocket()

--- a/src/Socket/AdapterSocket/RejectAdapter.swift
+++ b/src/Socket/AdapterSocket/RejectAdapter.swift
@@ -7,7 +7,7 @@ public class RejectAdapter: AdapterSocket {
         self.delay = delay
     }
 
-    override func openSocketWith(session: ConnectSession) {
+    override public func openSocketWith(session: ConnectSession) {
         super.openSocketWith(session: session)
 
         QueueFactory.getQueue().asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(delay)) {

--- a/src/Socket/AdapterSocket/Shadowsocks/ShadowsocksAdapter.swift
+++ b/src/Socket/AdapterSocket/Shadowsocks/ShadowsocksAdapter.swift
@@ -45,7 +45,7 @@ public class ShadowsocksAdapter: AdapterSocket {
         streamObfuscator.outputStreamProcessor = cryptor
     }
 
-    override func openSocketWith(session: ConnectSession) {
+    override public func openSocketWith(session: ConnectSession) {
         super.openSocketWith(session: session)
 
         do {

--- a/src/Socket/AdapterSocket/SpeedAdapter.swift
+++ b/src/Socket/AdapterSocket/SpeedAdapter.swift
@@ -8,7 +8,7 @@ public class SpeedAdapter: AdapterSocket, SocketDelegate {
 
     fileprivate var _shouldConnect: Bool = true
 
-    override func openSocketWith(session: ConnectSession) {
+    override public func openSocketWith(session: ConnectSession) {
         for (adapter, _) in adapters {
             adapter.observer = nil
         }


### PR DESCRIPTION
or it will not be able to be overridden.