### PR TITLE
Fix crash "load from misaligned raw pointer"

### DIFF
--- a/src/IPStack/DNS/DNSSession.swift
+++ b/src/IPStack/DNS/DNSSession.swift
@@ -42,3 +42,9 @@ open class DNSSession {
         requestIPPacket = packet
     }
 }
+
+extension DNSSession: CustomStringConvertible {
+    public var description: String {
+        return "<\(type(of: self)) domain: \(self.requestMessage.queries.first!.name) realIP: \(realIP) fakeIP: \(fakeIP)>"
+    }
+}

--- a/src/RawSocket/NWUDPSocket.swift
+++ b/src/RawSocket/NWUDPSocket.swift
@@ -87,12 +87,12 @@ public class NWUDPSocket: NSObject {
      
      - parameter data: The data to send.
      */
-    func write(data: Data) {
+    public func write(data: Data) {
         pendingWriteData.append(data)
         checkWrite()
     }
     
-    func disconnect() {
+    public func disconnect() {
         session.cancel()
         timer.cancel()
     }

--- a/src/Utils/BinaryDataScanner.swift
+++ b/src/Utils/BinaryDataScanner.swift
@@ -58,7 +58,7 @@ open class BinaryDataScanner {
         }
 
         let v = data.withUnsafeRawPointer {
-            $0.advanced(by: position).load(as: T.self)
+            $0.advanced(by: position).assumingMemoryBound(to: T.self).pointee
         }
         position += MemoryLayout<T>.size
         return littleEndian ? v.littleEndian : v.bigEndian

--- a/src/Utils/IPAddress.swift
+++ b/src/Utils/IPAddress.swift
@@ -96,10 +96,10 @@ public class IPAddress: CustomStringConvertible, Hashable, Comparable {
     public convenience init(fromBytesInNetworkOrder ptr: UnsafeRawPointer, family: Family = .IPv4) {
         switch family {
         case .IPv4:
-            let addr = ptr.load(as: in_addr.self)
+            let addr = ptr.assumingMemoryBound(to: in_addr.self).pointee
             self.init(fromInAddr: addr)
         case .IPv6:
-            let addr6 = ptr.load(as: in6_addr.self)
+            let addr6 = ptr.assumingMemoryBound(to: in6_addr.self).pointee
             self.init(fromIn6Addr: addr6)
         }
     }


### PR DESCRIPTION
When use `DNSServer` with `interface.registerStack(dnsServer)`, it will crash.


Log:

fatal error: load from misaligned raw pointer

```
* thread #3: tid = 0x1d9943, 0x00000001008811fc libswiftCore.dylib`function signature specialization <preserving fragile attribute, Arg[2] = Dead, Arg[3] = Dead> of Swift._fatalErrorMessage (Swift.StaticString, Swift.StaticString, Swift.StaticString, Swift.UInt, flags : Swift.UInt32) -> Swift.Never + 120, queue = 'NEKit.ProcessingQueue', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1008811fc)
  * frame #0: 0x00000001008811fc libswiftCore.dylib`function signature specialization <preserving fragile attribute, Arg[2] = Dead, Arg[3] = Dead> of Swift._fatalErrorMessage (Swift.StaticString, Swift.StaticString, Swift.StaticString, Swift.UInt, flags : Swift.UInt32) -> Swift.Never + 120
    frame #1: 0x0000000100858718 libswiftCore.dylib`Swift.UnsafeRawPointer.load <A> (fromByteOffset : Swift.Int, as : A.Type) -> A + 100
    frame #2: 0x000000010051acb4 NEKit`BinaryDataScanner.($0=(_rawValue = 0x0000000143d46eb0), self=(data = 42 bytes, littleEndian = false, position = 33)) -> A?).(closure #1) + 100 at BinaryDataScanner.swift:64
    frame #3: 0x0000000100508138 NEKit`Data.(ptr=0x0000000143d46eb0, body=0x000000010051ad08 NEKit`partial apply forwarder for NEKit.BinaryDataScanner.(read <A where A: NEKit.BinaryReadable> () -> Swift.Optional<A>).(closure #1) at BinaryDataScanner.swift, $error=Error @ 0x000000016df6dd50) throws -> A) throws -> A).(closure #1) + 96 at Data.swift:7
    frame #4: 0x0000000100cf2a08 libswiftFoundation.dylib`Foundation.Data.withUnsafeBytes <A, B> ((Swift.UnsafePointer<B>) throws -> A) throws -> A + 176
    frame #5: 0x000000010050807c NEKit`Data.withUnsafeRawPointer<A> (body=0x000000010051ad08 NEKit`partial apply forwarder for NEKit.BinaryDataScanner.(read <A where A: NEKit.BinaryReadable> () -> Swift.Optional<A>).(closure #1) at BinaryDataScanner.swift, self=42 bytes, $error=Error @ 0x000000016df6dd50) throws -> A) throws -> A + 164 at Data.swift:8
    frame #6: 0x000000010051aa9c NEKit`BinaryDataScanner.read<A where ...> (self=(data = 42 bytes, littleEndian = false, position = 33)) -> A? + 268 at BinaryDataScanner.swift:65
    frame #7: 0x000000010051af10 NEKit`BinaryDataScanner.read16(self=(data = 42 bytes, littleEndian = false, position = 33)) -> UInt16? + 72 at BinaryDataScanner.swift:86
    frame #8: 0x00000001005331a0 NEKit`static DNSNameConverter.getNamefromData(data=42 bytes, offset=12, base=0, self=NEKit.DNSNameConverter) -> (String, Int) + 188 at DNSMessage.swift:362
    frame #9: 0x0000000100532d20 NEKit`DNSQuery.init(payload=42 bytes, offset=12, base=0) -> DNSQuery? + 88 at DNSMessage.swift:245
    frame #10: 0x000000010052ffb0 NEKit`DNSQuery.__allocating_init(payload : Data, offset : Int, base : Int) -> DNSQuery? + 72 at DNSMessage.swift:0
    frame #11: 0x000000010052e5d0 NEKit`DNSMessage.init(payload=42 bytes) -> DNSMessage? + 2588 at DNSMessage.swift:88
    frame #12: 0x000000010052fcdc NEKit`DNSMessage.__allocating_init(payload : Data) -> DNSMessage? + 56 at DNSMessage.swift:0
    frame #13: 0x00000001004ca78c NEKit`DNSSession.init(packet=0x0000000143d46bb0) -> DNSSession? + 364 at DNSSession.swift:38
    frame #14: 0x00000001004ca95c NEKit`DNSSession.__allocating_init(packet : IPPacket) -> DNSSession? + 64 at DNSSession.swift:0
    frame #15: 0x00000001004e1dcc NEKit`DNSServer.input(packet=70 bytes, version=Int64(2), self=0x0000000143e34ac0) -> Bool + 440 at DNSServer.swift:133
    frame #16: 0x00000001004e4918 NEKit`protocol witness for IPStackProtocol.input(packet : Data, version : NSNumber?) -> Bool in conformance DNSServer + 80 at DNSServer.swift:0
    frame #17: 0x00000001004fee54 NEKit`TUNInterface.(packets=1 value, self=0x0000000143d39690, versions=1 value) -> ()).(closure #1).(closure #1) + 584 at TUNInterface.swift:66
    frame #18: 0x00000001004e1330 NEKit`thunk + 44 at DNSServer.swift:0
    frame #19: 0x00000001920b21fc libdispatch.dylib`_dispatch_call_block_and_release + 24
    frame #20: 0x00000001920b21bc libdispatch.dylib`_dispatch_client_callout + 16
    frame #21: 0x00000001920c03dc libdispatch.dylib`_dispatch_queue_serial_drain + 928
    frame #22: 0x00000001920b59a4 libdispatch.dylib`_dispatch_queue_invoke + 652
    frame #23: 0x00000001920c08d8 libdispatch.dylib`_dispatch_queue_override_invoke + 360
    frame #24: 0x00000001920c234c libdispatch.dylib`_dispatch_root_queue_drain + 572
    frame #25: 0x00000001920c20ac libdispatch.dylib`_dispatch_worker_thread3 + 124
    frame #26: 0x00000001922bb2a0 libsystem_pthread.dylib`_pthread_wqthread + 1288
    frame #27: 0x00000001922bad8c libsystem_pthread.dylib`start_wqthread + 4
    
```


UnsafeRawPointer.load method **crashes** if following precondition is not met.

https://github.com/apple/swift/blob/master/stdlib/public/core/UnsafeRawPointer.swift.gyb#L771

```Swift
  public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
    _debugPrecondition(0 == (UInt(bitPattern: self + offset)
        & (UInt(MemoryLayout<T>.alignment) - 1)),
      "load from misaligned raw pointer")

    return Builtin.loadRaw((self + offset)._rawValue)
  }
```


