### PR TITLE
Fix crash by using QueueFactory.executeOnQueueSynchronizedly 

### DIFF
--- a/src/IPStack/DNS/DNSServer.swift
+++ b/src/IPStack/DNS/DNSServer.swift
@@ -202,7 +202,7 @@ open class DNSServer: DNSResolverDelegate, IPStackProtocol {
 
     func lookupFakeIP(_ address: IPAddress) -> DNSSession? {
         var session: DNSSession?
-        queue.sync {
+        QueueFactory.executeOnQueueSynchronizedly {
             session = self.fakeSessions[address]
         }
         return session


### PR DESCRIPTION
instead of queue.sync.

Or it will cause deadlock like this:

<img width="356" alt="2017-03-04 1 37 13" src="https://cloud.githubusercontent.com/assets/35811/23576427/bdd73b0c-00df-11e7-98ba-09fa80697f6d.png">
