### PR TITLE
Fix memory issues

### DIFF
--- a/src/RawSocket/NWUDPSocket.swift
+++ b/src/RawSocket/NWUDPSocket.swift
@@ -108,7 +108,9 @@ public class NWUDPSocket: NSObject {
                 self.delegate?.didCancel(socket: self)
             }
         case .ready:
-            checkWrite()
+            queueCall {
+                self.checkWrite()
+            }
         default:
             break
         }
@@ -136,7 +138,7 @@ public class NWUDPSocket: NSObject {
                 self.checkWrite()
             }
         }
-        self.pendingWriteData.removeAll(keepingCapacity: true)
+        self.pendingWriteData.removeAll()
     }
     
     private func updateActivityTimer() {


### PR DESCRIPTION
This PR fixed most of the memory problems, but there is still some leakage is not a big problem ( DNSServer, DebugObservers, System Foundations ).  

`tun2sock` also got a [PR](https://github.com/zhuhaow/tun2socks/pull/3)

Test code:

I only used the `DirectAdapter`.

```Swift
NEKit.Opt.MAXNWTCPSocketReadDataSize = 60 * 1024

let interface = TUNInterface(packetFlow: packetFlow)
RawSocketFactory.TunnelProvider = self

interface.register(stack: UDPDirectStack())

let tcpStack = TCPStack.stack
proxyServer = NEKit.ProxyServer(address: nil, port: NEKit.Port(port: 0))
try! proxyServer?.start()
tcpStack.proxyServer = proxyServer
interface.register(stack: tcpStack)

self.interface = interface
```

Before

![before](https://cloud.githubusercontent.com/assets/548532/23746671/b347d89c-04f7-11e7-8cf7-7841402f01fa.png)

After

![after](https://cloud.githubusercontent.com/assets/548532/23746684/c1c415e8-04f7-11e7-8eb2-18eddbfe6531.png)

![leaks](https://cloud.githubusercontent.com/assets/548532/23746688/c63152a8-04f7-11e7-9ef8-ed6243ad526f.png)

PS:
1. Not sure why `self.pendingWriteData.removeAll(keepingCapacity: true)` cause leaks ... 
2. Set `MEM_SIZE 1600` at `lwip` will reduce 1M memory usage. 


