### PR TITLE
Try to resolve iOS 12 crash.

### DIFF
--- a/src/RawSocket/NWTCPSocket.swift
+++ b/src/RawSocket/NWTCPSocket.swift
@@ -96,6 +96,14 @@ public class NWTCPSocket: NSObject, RawTCPSocketProtocol {
         }
     }
 
+    func didDisconnect() {
+        queueCall {
+            let delegate = self.delegate
+            self.delegate = nil
+            delegate?.didDisconnectWith(socket: self)
+        }
+    }
+
     /**
      Disconnect the socket immediately.
      */
@@ -231,11 +239,7 @@ public class NWTCPSocket: NSObject, RawTCPSocketProtocol {
             cancel()
         case .cancelled:
             cancelled = true
-            queueCall {
-                let delegate = self.delegate
-                self.delegate = nil
-                delegate?.didDisconnectWith(socket: self)
-            }
+            self.didDisconnect()
         default:
             break
         }
@@ -311,7 +315,10 @@ public class NWTCPSocket: NSObject, RawTCPSocketProtocol {
     }
 
     private func cancel() {
+        connection?.removeObserver(self, forKeyPath: "state")
         connection?.cancel()
+        connection = nil
+        self.didDisconnect()
     }
 
     private func checkStatus() {


### PR DESCRIPTION
```
* thread #12, queue = 'Network.framework', stop reason = EXC_BAD_ACCESS (code=1, address=0x104e26b8)
  * frame #0: 0x00000001a4746df0 libobjc.A.dylib`objc_msgSend + 16
    frame #1: 0x00000001a542b1c4 CoreFoundation`__CFCopyFormattingDescription + 452
    frame #2: 0x00000001a543ca50 CoreFoundation`__CFStringAppendFormatCore + 7788
    frame #3: 0x00000001a543de1c CoreFoundation`_CFStringCreateWithFormatAndArgumentsAux2 + 132
    frame #4: 0x00000001a5476f30 CoreFoundation`+[NSException raise:format:] + 72
    frame #5: 0x00000001a5eb32c4 Foundation`-[NSObject(NSKeyValueObserving) observeValueForKeyPath:ofObject:change:context:] + 176
    frame #6: 0x00000001a5e2dda4 Foundation`NSKeyValueNotifyObserver + 304
    frame #7: 0x00000001a5e2d964 Foundation`NSKeyValueDidChange + 380
    frame #8: 0x00000001a5eb30d4 Foundation`NSKeyValueDidChangeWithPerThreadPendingNotifications.llvm.9336049896169916652 + 140
    frame #9: 0x00000001cf410b10 Network`__36-[NWTCPConnection setupEventHandler]_block_invoke + 96
    frame #10: 0x00000001a4eaac4c libdispatch.dylib`_dispatch_block_async_invoke2 + 104
    frame #11: 0x00000001a4e69808 libdispatch.dylib`_dispatch_client_callout + 16
    frame #12: 0x00000001a4ea5828 libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$armv81 + 544
    frame #13: 0x00000001a4ea63a4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$armv81 + 468
    frame #14: 0x00000001a4eae904 libdispatch.dylib`_dispatch_workloop_worker_thread + 584
    frame #15: 0x00000001a509e1ac libsystem_pthread.dylib`_pthread_wqthread + 312
    frame #16: 0x00000001a509e068 libsystem_pthread.dylib`start_wqthread + 4
(lldb) 
```

It was the new `Network.framework` that had problems with KVO's memory management. I temporarily solved it and made some changes to NEKit, but I didn't test it. I hope someone can verify it.